### PR TITLE
Fix issues with PM2 clustering and empty payload data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -126,8 +126,12 @@ Object.keys(Datastore.prototype).forEach(function (methodName) {
           data.push(chunk)
         })
         response.on('end', function () {
-          var payload = JSON.parse(data.join(''))
-          
+          var payload = undefined;
+
+          if (data.length > 0)  {
+            payload = JSON.parse(data.join(''))
+          }
+
           if (response.statusCode === 200) {
             return cb(null, payload)
           } else {

--- a/index.js
+++ b/index.js
@@ -1,17 +1,20 @@
 var path = require('path')
 var http = require('http')
-
 var debug = require('debug')('nedb-party')
-
 var Datastore = require('nedb')
 
-var stores = {}
+var lock = require('./lock')
 
+var stores = {}
 var listening = false
 
 var server = http.createServer(function handleRequest (request, response) {
-  readAll(request, function(err, data) {
-    var payload = JSON.parse(data)
+  var data = []
+  request.on('data', function (chunk) {
+    data.push(chunk)
+  })
+  request.on('end', function () {
+    var payload = JSON.parse(data.join(''))
 
     var options = payload.storeOptions
     var methodName = payload.methodName
@@ -40,11 +43,16 @@ function startServer (cb) {
   if (listening)
     return cb(null, server)
 
-  server.listen(40404, function (err) {
-    listening = !err
-
-    return cb(err, listening ? server : null)
-  })
+  lock.lock(function(err) {
+    if (!err) {
+      server.listen(40404, function (err) {
+        listening = !err
+        return cb(err, listening ? server : null)
+      })
+    } else {
+      return cb(err, null)
+    }
+  });
 }
 
 function DatastoreProxy (options) {
@@ -113,9 +121,13 @@ Object.keys(Datastore.prototype).forEach(function (methodName) {
 
       request.on('response', function (response) {
         response.setEncoding('utf8')
-
-        readAll(response, function(err, data) {
-          var payload = JSON.parse(data)
+        var data = []
+        response.on('data', function (chunk) {
+          data.push(chunk)
+        })
+        response.on('end', function () {
+          var payload = JSON.parse(data.join(''))
+          
           if (response.statusCode === 200) {
             return cb(null, payload)
           } else {
@@ -128,21 +140,5 @@ Object.keys(Datastore.prototype).forEach(function (methodName) {
     })
   }
 })
-
-
-function readAll(stream, cb) {
-  var data = []
-  stream.on('data', function (chunk) {
-    data.push(chunk)
-  })
-  stream.once('end', function () {
-    cb(null, data.join(''));
-    cb = function() {}
-  })
-  stream.once('error', function(err) {
-    cb(err);
-    cb = function() {}
-  })
-}
 
 module.exports = DatastoreProxy

--- a/lock.js
+++ b/lock.js
@@ -1,0 +1,44 @@
+
+/* From Node.js in Practice (https://github.com/alexyoung/nodeinpractice/tree/master/listings/file-system/locking) */
+
+var fs = require('fs')
+var hasLock = false
+var lockDir = 'config.lock'
+
+exports.lock = function (cb) {
+  if (hasLock) return cb()
+  fs.mkdir(lockDir, function (err) {
+    if (err) return cb(err)
+
+    fs.writeFile(lockDir+'/'+process.pid, 'lock', function (err) {
+      if (err) console.error(err)
+      hasLock = true
+      return cb()
+    })
+  })
+}
+
+exports.unlock = function (cb) {
+  if (!hasLock) return cb()
+  fs.unlink(lockDir+'/'+process.pid, function (err) {
+    if (err) return cb(err)
+
+    fs.rmdir(lockDir, function (err) {
+      if (err) return cb(err)
+      hasLock = false
+      cb()
+    })
+  })
+}
+
+function deleteLock() {
+  if (hasLock) {
+    fs.unlinkSync(lockDir+'/'+process.pid)
+    fs.rmdirSync(lockDir)
+    console.log('Removed lock')
+  }
+}
+
+process.on('exit', function () {
+  deleteLock()
+})


### PR DESCRIPTION
Hello, 

I'm using PM2 with clustering enabled and this causes the all processes to be able to listen on the same port which prevents the single-process access to the db. So instead of using the error from http.listen I added a locking mechanism based on creating a directory (described in the 'Node.js in Action' book).

Another problem I encountered was that sometimes the http request payload data is empty and JSON.parse caused an exception. Fixed that too.